### PR TITLE
Use fully-qualified DB names in LookML

### DIFF
--- a/views/distribution_centers.view.lkml
+++ b/views/distribution_centers.view.lkml
@@ -1,5 +1,5 @@
 view: distribution_centers {
-  sql_table_name: `looker_ecomm.distribution_centers`
+  sql_table_name: `cloud-training-demos.looker_ecomm.distribution_centers`
     ;;
   drill_fields: [id]
 

--- a/views/event_session_facts.view.lkml
+++ b/views/event_session_facts.view.lkml
@@ -9,7 +9,7 @@ view: event_session_facts {
           ,LAST_VALUE (created_at) OVER (PARTITION BY session_id ORDER BY created_at ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS session_end
           ,FIRST_VALUE (event_type) OVER (PARTITION BY session_id ORDER BY created_at ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS session_landing_page
           ,LAST_VALUE (event_type) OVER (PARTITION BY session_id ORDER BY created_at ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS session_exit_page
-        FROM `looker_ecomm`.events
+        FROM `cloud-training-demos.looker_ecomm.events`
       )
       SELECT * FROM session_facts
       GROUP BY 1, 2, 3, 4, 5, 6

--- a/views/event_session_funnel.view.lkml
+++ b/views/event_session_funnel.view.lkml
@@ -20,7 +20,7 @@ view: event_session_funnel {
               THEN created_at
               ELSE NULL END
             ) as event3_time
-      FROM `looker_ecomm`.events
+      FROM `cloud-training-demos.looker_ecomm.events`
       GROUP BY 1
  ;;
   }

--- a/views/events.view.lkml
+++ b/views/events.view.lkml
@@ -1,5 +1,5 @@
 view: events {
-  sql_table_name: `looker_ecomm.events`
+  sql_table_name: `cloud-training-demos.looker_ecomm.events`
     ;;
   drill_fields: [id]
 

--- a/views/inventory_items.view.lkml
+++ b/views/inventory_items.view.lkml
@@ -1,5 +1,5 @@
 view: inventory_items {
-  sql_table_name: `looker_ecomm.inventory_items`
+  sql_table_name: `cloud-training-demos.looker_ecomm.inventory_items`
     ;;
   drill_fields: [id]
 

--- a/views/order_items.view.lkml
+++ b/views/order_items.view.lkml
@@ -1,5 +1,5 @@
 view: order_items {
-  sql_table_name: `looker_ecomm.order_items`
+  sql_table_name: `cloud-training-demos.looker_ecomm.order_items`
     ;;
   drill_fields: [order_item_id]
 

--- a/views/products.view.lkml
+++ b/views/products.view.lkml
@@ -1,5 +1,5 @@
 view: products {
-  sql_table_name: `looker_ecomm.products`
+  sql_table_name: `cloud-training-demos.looker_ecomm.products`
     ;;
   drill_fields: [id]
 

--- a/views/users.view.lkml
+++ b/views/users.view.lkml
@@ -1,5 +1,5 @@
 view: users {
-  sql_table_name: `looker_ecomm.users`
+  sql_table_name: `cloud-training-demos.looker_ecomm.users`
     ;;
   drill_fields: [id]
 


### PR DESCRIPTION
Use fully-qualified names (https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#table_name) for all BigQuery tables so the LookML files work when executed from a project other than `cloud-training-demos`.